### PR TITLE
fix: stuck keys bug

### DIFF
--- a/lib/widgets/calculator_view.dart
+++ b/lib/widgets/calculator_view.dart
@@ -102,6 +102,7 @@ class _CalculatorViewState extends State<CalculatorView>
                       return GestureDetector(
                         onTapDown: (_) => widget.onKeyDown(key.type),
                         onTapUp: (_) => widget.onKeyUp(key.type),
+                        onTapCancel: () => widget.onKeyUp(key.type),
                         child: KeyTapEffect(
                           config: widget.config,
                           in3d: animationController.isCompleted,


### PR DESCRIPTION
Fixes stuck keys bug by adding `onTapCancel` method to `GestureDetector`